### PR TITLE
chore(provider)  Fixed deprecated method

### DIFF
--- a/lib/provider.dart
+++ b/lib/provider.dart
@@ -46,7 +46,7 @@ class Provider<T extends Store> extends StatefulWidget {
   static T of<T extends Store>(BuildContext context) {
     final type = _typeOf<_InheritedProvider<T>>();
     final _InheritedProvider<T> provider =
-        context.inheritFromWidgetOfExactType(type);
+        context.dependOnInheritedWidgetOfExactType(aspect: type);
 
     if (provider == null) {
       throw ProviderNotFoundError(T, context.widget.runtimeType);


### PR DESCRIPTION

The inheritFromWidgetOfExactType method was deprecated in flutter version 2.0 so now the dependOnInheritedWidgetOfExactType must be used